### PR TITLE
Fix: data source index verification

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,1 +1,1 @@
-docker build -t proto-snapshot-dequeuer . --no-cache
+docker build -t sequencer-dequeuer . --no-cache

--- a/pkgs/constants.go
+++ b/pkgs/constants.go
@@ -10,7 +10,7 @@ const (
 
 // General Key Constants
 const (
-	CurrentDay                      = "CurrentDay"
+	CurrentDay                      = "CurrentDayKey"
 	CurrentEpoch                    = "CurrentEpochID"
 	CollectorKey                    = "SnapshotCollector"
 	FlaggedSnapshotterKey           = "FlaggedSnapshotterKey"

--- a/pkgs/redis/keys.go
+++ b/pkgs/redis/keys.go
@@ -74,5 +74,5 @@ func GetSnapshotterNodeVersion(dataMarketAddress string, snapshotterAddress stri
 }
 
 func DataMarketCurrentDay(dataMarketAddress string) string {
-	return fmt.Sprintf("%s.%s", strings.ToLower(dataMarketAddress), pkgs.CurrentDay)
+	return fmt.Sprintf("%s.%s", pkgs.CurrentDay, strings.ToLower(dataMarketAddress))
 }


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #19

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
Data source index verification fails once the day rolls over on the data market contract.

### New expected behaviour
The current day is correctly handled by the dequeuer allowing for the verification to complete successfully on a new day. There was a mismatch between the key that the protocol-state-cacher was using to store the current day and the key that the dequeuer was using to retrieve the day.

I have also updated the name in build-docker.sh to match the expected name in run.sh.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
- `pkgs/redis/keys.go`
- `pkgs/constants.go`
- `build-docker.sh`

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
