### PR TITLE
Feat/atomic submission setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,8 @@ FROM scratch
 # Copy the binary from the builder stage
 COPY --from=builder /dequeuer /dequeuer
 
+# Copy CA certificates from the builder stage
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Command to run the application
 CMD ["/dequeuer"]

--- a/pkgs/dequeuer/submissionHandler.go
+++ b/pkgs/dequeuer/submissionHandler.go
@@ -81,71 +81,12 @@ func (sh *SubmissionHandler) Start() {
 }
 
 // verifyAndStoreSubmission verifies the submission and stores it in Redis
-func (s *SubmissionHandler) verifyAndStoreSubmission(details SubmissionDetails) (err error) {
-	submissionCountIncremented := false
-	decrementGuard := false // Flag to prevent decrement after successful SetSubmission
-	slotIDStr := ""
-	slotEpochCounterKey := ""
-
-	defer func() {
-		// Check if an error occurred, if the count was incremented for a non-full node,
-		// and if the submission wasn't successfully stored yet (decrementGuard is false).
-		if err != nil && submissionCountIncremented && !decrementGuard {
-			if errDecr := redis.RedisClient.Decr(context.Background(), slotEpochCounterKey).Err(); errDecr != nil {
-				log.Warnf("Failed to decrement slot epoch counter %s after failed submission: %v", slotEpochCounterKey, errDecr)
-			} else {
-				// Log the successful decrement due to failure
-				log.Debugf("🔒🔄 Decremented slot epoch counter %s due to submission failure after initial increment", slotEpochCounterKey)
-			}
-		}
-	}()
-
+func (s *SubmissionHandler) verifyAndStoreSubmission(details SubmissionDetails) error {
 	// Recover the snapshotter address from the signature
 	snapshotterAddr, err := utils.RecoverAddress(utils.HashRequest(details.submission.Request), common.Hex2Bytes(details.submission.Signature))
 	if err != nil {
 		log.Errorf("Failed to recover snapshotter address: %s", err.Error())
-		err = fmt.Errorf("snapshotter address recovery error: %s", err.Error())
-		return err
-	}
-
-	// Optimistic Increment & Lock for non-full nodes
-	if !isFullNode(snapshotterAddr.Hex()) {
-		slotIDStr = strconv.FormatUint(details.submission.Request.SlotId, 10)
-		slotEpochCounterKey = redis.SlotEpochSubmissionsKey(details.dataMarketAddress, slotIDStr, details.submission.Request.EpochId)
-		var count int64
-		count, err = redis.Incr(context.Background(), slotEpochCounterKey)
-		if err != nil {
-			log.Errorf("Failed to increment slot epoch counter %s: %v", slotEpochCounterKey, err)
-			err = fmt.Errorf("redis client failure incrementing count key %s: %w", slotEpochCounterKey, err)
-			return err
-		}
-
-		submissionCountIncremented = true
-		log.Debugf("🔒📈 Incremented slot epoch counter %s to %d", slotEpochCounterKey, count) // Log successful increment
-
-		// Set expiry for the counter key right after incrementing
-		if errExp := redis.RedisClient.Expire(context.Background(), slotEpochCounterKey, 5*time.Minute).Err(); errExp != nil {
-			log.Warnf("Failed to set expiry for slot epoch counter %s: %v", slotEpochCounterKey, errExp)
-		}
-
-		if count > 2 {
-			log.Errorf("Slot epoch submission count exceeded for slot %s (count: %d)", slotIDStr, count)
-			redisKey := redis.SlotEpochSubmissionCountExceeded(details.dataMarketAddress, slotIDStr, details.submission.Request.EpochId)
-			if errSet := redis.Set(context.Background(), redisKey, "true", 5*time.Minute); errSet != nil {
-				log.Errorf("Failed to set Redis flag for exceeded submission count %s: %s", redisKey, errSet.Error())
-			}
-
-			// Decrement the counter as this submission is rejected due to exceeding the limit
-			if errDecr := redis.RedisClient.Decr(context.Background(), slotEpochCounterKey).Err(); errDecr != nil {
-				log.Warnf("Failed to decrement slot epoch counter %s after exceeding limit: %v", slotEpochCounterKey, errDecr)
-			} else {
-				log.Debugf("🔒🔄 Decremented slot epoch counter %s because limit was exceeded (count: %d)", slotEpochCounterKey, count)
-			}
-			submissionCountIncremented = false
-
-			err = fmt.Errorf("slot epoch submission count exceeded for slot %s", slotIDStr)
-			return err
-		}
+		return fmt.Errorf("snapshotter address recovery error: %s", err.Error())
 	}
 
 	// Log and store node version if present, otherwise set default version
@@ -451,77 +392,96 @@ func (s *SubmissionHandler) verifyAndStoreSubmission(details SubmissionDetails) 
 	}
 
 	value := fmt.Sprintf("%s.%s", details.submissionID.String(), protojson.Format(details.submission))
-	submissionJSON, err := json.Marshal(details.submission)
-	if err != nil {
-		log.Errorf("Error serializing submission for pipeline: %v", err)
-		err = fmt.Errorf("json marshalling error: %s", err.Error()) // Set named error
-		return err                                                  // Defer handles decrement
-	}
 
-	// Prepare keys
+	// Create the submission set key
 	submissionSetByHeaderKey := redis.SubmissionSetByHeaderKey(
 		details.dataMarketAddress,
 		details.submission.Request.EpochId,
 		details.submission.Header,
 	)
-	activeSnapshottersKey := redis.ActiveSnapshottersForEpoch(details.dataMarketAddress, details.submission.Request.EpochId)
-	epochSubmissionKey := redis.EpochSubmissionsKey(details.dataMarketAddress, details.submission.Request.EpochId)
-	slotIDStrForActiveSet := strconv.FormatUint(details.submission.Request.SlotId, 10)
 
-	// Start Redis Pipeline
-	ctx := context.Background()
-	pipe := redis.RedisClient.Pipeline()
-	defer pipe.Close()
-
-	log.Debugf("🚀 Starting Redis pipeline for submission ID %s", details.submissionID.String())
-
-	// Queue commands equivalent to SetSubmission(submissionKey, value, submissionSetByHeaderKey, 20m)
-	pipe.SAdd(ctx, submissionSetByHeaderKey, submissionKey) // Add the key to the set
-	pipe.Expire(ctx, submissionSetByHeaderKey, 20*time.Minute)
-	pipe.Set(ctx, submissionKey, value, 20*time.Minute)
-
-	// Queue adding slot to active set
-	pipe.SAdd(ctx, activeSnapshottersKey, slotIDStrForActiveSet)
-
-	// Queue expiry for active set
-	shouldSetExpiry := !s.isActiveSnapshotterExpirySetForEpoch(details.dataMarketAddress, details.submission.Request.EpochId)
-	if shouldSetExpiry {
-		pipe.Expire(ctx, activeSnapshottersKey, 30*time.Minute)
-		log.Debugf("Pipeline: Queued EXPIRE for active snapshotters key %s", activeSnapshottersKey)
-	}
-
-	// Queue HSet for epoch submissions raw dump
-	pipe.HSet(ctx, epochSubmissionKey, details.submissionID.String(), submissionJSON)
-	pipe.Expire(ctx, epochSubmissionKey, 30*time.Minute)
-
-	_, execErr := pipe.Exec(ctx)
-	if execErr != nil {
-		errMsg := fmt.Sprintf("Failed to execute submission Redis pipeline for submission ID %s: %s", details.submissionID.String(), execErr.Error())
+	// Store the submission in Redis
+	if err := redis.SetSubmission(context.Background(), submissionKey, value, submissionSetByHeaderKey, 20*time.Minute); err != nil {
+		errMsg := fmt.Sprintf("Failed to set submission (slot ID: %d, epoch ID: %d, project ID: %s) in Redis: %s",
+			details.submission.Request.SlotId, details.submission.Request.EpochId, details.submission.Request.ProjectId, err.Error())
 		reporting.SendFailureNotification(pkgs.VerifyAndStoreSubmission, errMsg, time.Now().String(), "High")
 		log.Error(errMsg)
-		err = fmt.Errorf("redis pipeline execution error: %w", execErr)
 		return err
 	}
 
-	log.Debugf("✅ Redis pipeline executed successfully for submission ID %s", details.submissionID.String())
+	log.Debugf(
+		"✅ Successfully set submission with set %s and key %s for slot %d, epoch %d, project %s",
+		submissionSetByHeaderKey,
+		submissionKey,
+		details.submission.Request.SlotId,
+		details.submission.Request.EpochId,
+		details.submission.Request.ProjectId,
+	)
 
-	// Mark expiry as set in memory if it was queued and pipeline succeeded
-	if shouldSetExpiry {
-		s.markActiveSnapshotterExpirySetForEpoch(details.dataMarketAddress, details.submission.Request.EpochId)
-		log.Debugf("Marked expiry set in memory for epoch %d after successful pipeline", details.submission.Request.EpochId)
+	// Add slot to a set of active slots for this epoch
+	activeSnapshottersKey := redis.ActiveSnapshottersForEpoch(details.dataMarketAddress, details.submission.Request.EpochId)
+	if err := redis.RedisClient.SAdd(context.Background(), activeSnapshottersKey, strconv.FormatUint(details.submission.Request.SlotId, 10)).Err(); err != nil {
+		errMsg := fmt.Sprintf("Error tracking active slot: %s", err.Error())
+		reporting.SendFailureNotification(pkgs.VerifyAndStoreSubmission, errMsg, time.Now().String(), "High")
+		log.Error(errMsg)
 	}
 
-	// If submission setting was successful, prevent the defer from decrementing the counter
-	decrementGuard = true
+	// sets the expiry status in-memory as well so we dont make round trips to redis for this
+	if !s.isActiveSnapshotterExpirySetForEpoch(details.dataMarketAddress, details.submission.Request.EpochId) {
+		if err := redis.RedisClient.Expire(context.Background(), activeSnapshottersKey, 30*time.Minute).Err(); err != nil {
+			log.Errorf("Failed to set expiry for active snapshotters set: %v", err)
+		} else {
+			// Mark that we've set expiry for this epoch
+			s.markActiveSnapshotterExpirySetForEpoch(details.dataMarketAddress, details.submission.Request.EpochId)
+			log.Debugf("Set expiry for active snapshotters for epoch %d", details.submission.Request.EpochId)
+		}
+	}
 
-	// Log final state after successful submission setting
-	if submissionCountIncremented {
-		log.Debugf("✅ Successfully set submission and incremented count for slot %s", slotIDStr)
-	} else if isFullNode(snapshotterAddr.Hex()) {
-		log.Debugf("✅ Successfully set submission for slot %s (full node, no count increment)", new(big.Int).SetUint64(details.submission.Request.SlotId).String())
-	} else {
-		// This case should technically not be hit if the logic is correct, but included for completeness
-		log.Debugf("✅ Successfully set submission for slot %s (non-full node, count already existed or increment failed previously?)", slotIDStr)
+	// Marshal the submission data to store in Redis
+	submissionJSON, err := json.Marshal(details.submission)
+	if err != nil {
+		log.Errorf("Error serializing submission: %v", err)
+		return fmt.Errorf("json marshalling error: %s", err.Error())
+	}
+
+	// This Htable is the raw dump of all submissions for a given epoch and data market
+	epochSubmissionKey := redis.EpochSubmissionsKey(details.dataMarketAddress, details.submission.Request.EpochId)
+	if err := redis.RedisClient.HSet(context.Background(), epochSubmissionKey, details.submissionID.String(), submissionJSON).Err(); err != nil {
+		log.Errorf("Failed to write submission details to Redis: %v", err)
+		return fmt.Errorf("redis client failure: %s", err.Error())
+	}
+
+	// Set the expiry for the epoch submissions hash table
+	if err := redis.RedisClient.Expire(context.Background(), epochSubmissionKey, 30*time.Minute).Err(); err != nil {
+		log.Errorf("Failed to set expiry for epoch submissions hash table %s: %v", epochSubmissionKey, err)
+		return fmt.Errorf("redis client failure: %s", err.Error())
+	}
+
+	if !isFullNode(snapshotterAddr.Hex()) {
+		slotID := strconv.FormatUint(details.submission.Request.SlotId, 10)
+		slotEpochCounterKey := redis.SlotEpochSubmissionsKey(details.dataMarketAddress, slotID, details.submission.Request.EpochId)
+		count, err := redis.Incr(context.Background(), slotEpochCounterKey)
+		if err != nil {
+			log.Errorf("Failed to increment slot epoch counter: %v", err)
+			return fmt.Errorf("redis client failure: %s", err.Error())
+		} else {
+			if count > 2 {
+				log.Errorf("Slot epoch submission count exceeded for slot %s", slotID)
+
+				// Set a flag in Redis to indicate that the submission count exceeded
+				redisKey := redis.SlotEpochSubmissionCountExceeded(details.dataMarketAddress, slotID, details.submission.Request.EpochId)
+				if err := redis.Set(context.Background(), redisKey, "true", 5*time.Minute); err != nil {
+					log.Errorf("Failed to set Redis flag for exceeded submission count: %s", err.Error())
+					return fmt.Errorf("failed to set Redis flag: %s", err.Error())
+				}
+			}
+		}
+
+		// Set the expiry for the slot epoch counter key
+		if err := redis.RedisClient.Expire(context.Background(), slotEpochCounterKey, 5*time.Minute).Err(); err != nil {
+			log.Errorf("Failed to set expiry for slot epoch counter %s: %v", slotEpochCounterKey, err)
+			return fmt.Errorf("redis client failure: %s", err.Error())
+		}
 	}
 
 	return nil

--- a/pkgs/dequeuer/submissionHandler.go
+++ b/pkgs/dequeuer/submissionHandler.go
@@ -663,10 +663,11 @@ func (s *SubmissionHandler) startSubmissionDequeuer() {
 		log.Infof("🔄 Processing submission with ID %s for data market address %s with request details %+v", submissionDetails.submissionID.String(), submissionDetails.dataMarketAddress, submissionDetails.submission.Request)
 
 		if err := s.verifyAndStoreSubmission(submissionDetails); err != nil {
-			log.Errorf("Failed to verify and store submission with ID '%s': %s", submissionDetails.submissionID.String(), err.Error())
+			log.Errorf("❌ Failed to verify and store submission with ID '%s': %s", submissionDetails.submissionID.String(), err.Error())
+		} else {
+			// Log success only if verifyAndStoreSubmission returned nil error
+			log.Infof("✅ Successfully verified and stored submission with ID: %s", submissionDetails.submissionID.String())
 		}
-
-		log.Infof("✅ Successfully verified and stored submission with ID: %s", submissionDetails.submissionID.String())
 	}
 }
 

--- a/pkgs/redis/client.go
+++ b/pkgs/redis/client.go
@@ -19,51 +19,38 @@ type BoolCmd = redis.BoolCmd
 
 // --- ADDED SCRIPT DEFINITION AND LOADING FUNCTION ---
 const checkDuplicateAndIncrScript = `
--- KEYS[1]: submissionKey (e.g., submission:<epochID>:<projectID>:<slotID>:<dataMarketAddress>)
--- KEYS[2]: counterKey (e.g., submission:count:slot:<slotID>:<epochID>:<dataMarketAddress>)
--- KEYS[3]: exceededKey (e.g., submission:exceeded:slot:<slotID>:<epochID>:<dataMarketAddress>)
+-- KEYS[1]: counterKey (e.g., SlotEpochCounter.<dataMarketAddress>.<slotId>.<epochId>)
 -- ARGV[1]: limit (e.g., "2")
 -- ARGV[2]: counter expiry milliseconds (e.g., "300000" for 5 minutes)
--- ARGV[3]: exceeded flag expiry seconds (e.g., "300" for 5 minutes)
 --
 -- Returns:
 -- 0: OK (Counter incremented)
--- 1: Duplicate submission
--- 2: Submission limit reached (Counter not incremented)
+-- 1: Submission limit reached (Counter not incremented)
 
-local submission_key = KEYS[1]
-local counter_key = KEYS[2]
-local exceeded_key = KEYS[3]
+local counter_key = KEYS[1]
 local limit = tonumber(ARGV[1])
 local counter_expiry_ms = tonumber(ARGV[2])
-local exceeded_expiry_s = tonumber(ARGV[3])
 
--- 1. Check for duplicate submission
-if redis.call('EXISTS', submission_key) == 1 then
-  return 1 -- Duplicate
-end
-
--- 2. Check current count WITHOUT incrementing yet
+-- 1. Check current count WITHOUT incrementing yet
 local current_count_str = redis.call('GET', counter_key)
 local current_count = 0
 if current_count_str then
   current_count = tonumber(current_count_str) or 0
 end
 
--- 3. Check if limit is already reached
+-- 2. Check if limit is already reached
 if current_count >= limit then
-  -- Set exceeded flag (and its expiry) unconditionally if limit reached
-  redis.call('SET', exceeded_key, 'true', 'EX', exceeded_expiry_s)
-  return 2 -- Limit Reached
+  -- Do not increment, just return limit reached status
+  return 1 -- Limit Reached
 end
 
--- 4. Limit is not reached, proceed to increment
-local new_count = redis.call('INCR', counter_key)
+-- 3. Limit is not reached, proceed to increment
+redis.call('INCR', counter_key)
 
--- 5. Set expiry on counter key unconditionally after incrementing
+-- 4. Set expiry on counter key unconditionally after incrementing
 redis.call('PEXPIRE', counter_key, counter_expiry_ms)
 
--- 6. Return success indicator (counter was incremented)
+-- 5. Return success indicator (counter was incremented)
 return 0 -- OK
 `
 


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes https://github.com/PowerLoom/sequencer-dequeuer/issues/31

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The existing submission handling logic in `submissionHandler.go` performs multiple separate Redis operations to check submission counts, store snapshotter data, and track submission status. This includes increments, hash sets, and checks which are not atomic. If multiple submissions arrive concurrently for the same slot/epoch, it could lead to race conditions or incorrect state updates. Specifically, the check for the submission limit (`count > 2`) and the increment operation are separate steps. Some Redis keys (`GetSnapshotterSubmissionCountInSlot`, `GetSnapshotterSlotSubmissionsHtable`, `lastPingKey`) were being set but not utilized elsewhere in the sequencer components. The Docker image was missing CA certificates.

### New expected behaviour
This PR introduces an atomic mechanism for handling submission counting using a Redis Lua script (`checkDuplicateAndIncrScript`). This script atomically checks if the submission limit for a given data market, slot, and epoch has been reached *before* incrementing the counter. This prevents race conditions where the limit might be exceeded between the check and the increment.

The new logic:
1.  Loads the Lua script into Redis on startup.
2.  Executes the Lua script via `EVALSHA` within `verifyAndStoreSubmission` for non-full nodes.
3.  The script returns `0` if the counter was successfully incremented (limit not reached) or `1` if the limit was already reached.
4.  Handles `NOSCRIPT` errors by reloading the script and retrying the operation.
5.  If subsequent verification steps (like data source index validation) fail *after* the counter was incremented by the Lua script, a rollback mechanism (`attemptCounterRollback`) attempts to decrement the counter to maintain consistency.

### Change logs

#### Changed
- Replaced separate Redis checks and increments for slot/epoch submission counting with a single atomic Lua script execution (`EVALSHA`) in `submissionHandler.go`.
- Implemented error handling for `NOSCRIPT` errors during Lua script execution.
- Added a rollback mechanism (`attemptCounterRollback`) to decrement the counter if subsequent checks fail after a successful script execution.
- Updated logging messages for clarity.
- Added `ca-certificates.crt` to the Docker image.

#### Added
- Defined `checkDuplicateAndIncrScript` Lua script in `redis/client.go`.
- Added `LoadCheckDuplicateAndIncrScript` function to load the script into Redis on startup in `redis/client.go`.
- Added `attemptCounterRollback` function in `submissionHandler.go`.

#### Removed
- Removed Redis operations for `GetSnapshotterSubmissionCountInSlot`, `GetSnapshotterSlotSubmissionsHtable`, and `lastPingKey` in `submissionHandler.go`.
- Removed the check comparing submitted `epochId` against `config.SettingsObj.EpochAcceptanceWindow` in `submissionHandler.go`.
- Removed the non-atomic check and increment logic for `SlotEpochSubmissionsKey` in `submissionHandler.go`.

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Ensure the Redis instance used by the dequeuer supports Lua scripting (`EVALSHA`, `SCRIPT LOAD`). The application automatically loads the required script on startup. No other specific deployment changes are required beyond deploying the updated binary/image.